### PR TITLE
Refactored Terraform code: main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,13 +170,13 @@ resource "aws_lb_target_group" "instances" {
 
 resource "aws_lb_target_group_attachment" "django_instance_1" {
   target_group_arn = aws_lb_target_group.instances.arn
-  target_id        = aws_instance.django_app_instance_1.id
+  target_id        = aws_instance.django_app_instance[0].id
   port             = 8000
 }
 
 resource "aws_lb_target_group_attachment" "django_instance_2" {
   target_group_arn = aws_lb_target_group.instances.arn
-  target_id        = aws_instance.django_app_instance_2.id
+  target_id        = aws_instance.django_app_instance[1].id
   port             = 8000
 }
 

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,6 @@ resource "aws_instance" "django_app_instance" {
   #              echo "EC2 instance 2!" > index.html
   #              python3 -m http.server 8000 &
   #              EOF
-}
 
 # Virtual Private Cloud:
 data "aws_vpc" "default_vpc" {


### PR DESCRIPTION
In the refactored code, we defined the user data script as a variable to avoid repeating the same code block twice. We also used the count parameter to create two instances of the same resource with the same configuration. This makes the code more concise and easier to maintain. we added a tags block to the aws_instance resource and used the count.index interpolation syntax to append the index to the end of the resource name. The count.index starts from 0, so we added 1 to it to get the desired numbering (_1 and _2).